### PR TITLE
fixed a minor error in dot_prod() function

### DIFF
--- a/linear_algebra-1.ipynb
+++ b/linear_algebra-1.ipynb
@@ -1487,8 +1487,7 @@
     "            if verbose: print(f'\\tk = {k}')\n",
     "            for j in range(mx1.shape[1]):\n",
     "                if verbose: print(f'\\t\\tj = {j}')\n",
-    "                s = mx1[i, j] + mx2[j, k]\n",
-    "            mx3[i, k] = s\n",
+    "                mx3[i, k] += mx1[i, j] * mx2[j, k]\n",
     "    \n",
     "    return mx3\n",
     "            "
@@ -2227,7 +2226,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
dot_prod() ფუნქციის პირველ იმპლემენტაციაში პატარა შეცდომა იყო. ნამრავლის მაგივრად ჯამი ეწერა და თან სხვადასხვა წევრების წვლილები არ იკრიბებოდა. ამის შედეგად შესრულება შედარებით სწრაფად ხდებოდა, ვიდრე უნდა მომხდარიყო, მაგრამ პასუხი არასწორი ბრუნდებოდა.